### PR TITLE
flightgear-git: Depend on osgxr to enable VR

### DIFF
--- a/flightgear-git/.SRCINFO
+++ b/flightgear-git/.SRCINFO
@@ -1,6 +1,6 @@
 pkgbase = flightgear-git
 	pkgdesc = An open-source, multi-platform flight simulator
-	pkgver = 2020.4.0r15376.4e432b3f8
+	pkgver = 2020.4.0r15830.5d6ac7a1c
 	pkgrel = 1
 	url = https://home.flightgear.org
 	arch = x86_64
@@ -21,13 +21,13 @@ pkgbase = flightgear-git
 	depends = libxrandr
 	depends = glu
 	depends = openal
+	depends = osgxr
 	optdepends = qt5-base: fgfs --launcher
 	optdepends = qt5-declarative: fgfs --launcher
 	optdepends = flightgear-data
-	provides = flightgear=2020.4.0r15376.4e432b3f8
+	provides = flightgear=2020.4.0r15830.5d6ac7a1c
 	conflicts = flightgear
 	source = flightgear::git+https://git.code.sf.net/p/flightgear/flightgear#branch=next
 	sha256sums = SKIP
 
 pkgname = flightgear-git
-

--- a/flightgear-git/PKGBUILD
+++ b/flightgear-git/PKGBUILD
@@ -4,13 +4,13 @@
 # Contributor: Pascal Groschwitz <p.groschwitz@googlemail.com>
 
 pkgname=flightgear-git
-pkgver=2020.4.0r15376.4e432b3f8
+pkgver=2020.4.0r15830.5d6ac7a1c
 pkgrel=1
 pkgdesc="An open-source, multi-platform flight simulator"
 arch=('x86_64')
 url="https://home.flightgear.org"
 license=('GPL')
-depends=('libxmu' 'libxi' 'zlib' 'openscenegraph' 'libxrandr' 'glu' 'openal')
+depends=('libxmu' 'libxi' 'zlib' 'openscenegraph' 'libxrandr' 'glu' 'openal' 'osgxr')
 makedepends=('boost' 'cmake' 'git' 'mesa' 'sharutils' 'simgear' 'qt5-base' 'qt5-declarative' 'qt5-svg')
 optdepends=('qt5-base: fgfs --launcher'
             'qt5-declarative: fgfs --launcher'


### PR DESCRIPTION
Depend on osgxr so that VR support gets enabled.

Fixes #1